### PR TITLE
Remove sqeeze

### DIFF
--- a/lib/jekyll-archives.rb
+++ b/lib/jekyll-archives.rb
@@ -98,7 +98,7 @@ module Jekyll
       def remove_dashes(tags)
         cleaned_tags = []
         tags.each do |tag|
-          cleaned_tags << tag.gsub(/-/, ' ').squeeze
+          cleaned_tags << tag.gsub(/-/, ' ')
         end
         cleaned_tags
       end


### PR DESCRIPTION
the String `squeeze` method doesn't only remove extra spaces, it removes double letters, so that stuff like this was happening:

```
'presidential innovation fellows' => 'presidential inovation felows'
```

I removed it, so things should work now!